### PR TITLE
🔀 :: 토큰 재발급 받을때 기존의 RefreshToken 삭제

### DIFF
--- a/src/main/kotlin/com/project/goms/domain/auth/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/com/project/goms/domain/auth/usecase/ReissueTokenUseCase.kt
@@ -23,7 +23,7 @@ class ReissueTokenUseCase(
         val parsedRefreshToken = jwtParser.parseRefreshToken(refreshToken) ?: throw InvalidTokenTypeException()
         val refreshTokenEntity = refreshTokenRepository.findByIdOrNull(parsedRefreshToken) ?: throw ExpiredRefreshTokenException()
         val account = accountRepository.findByIdOrNull(refreshTokenEntity.accountIdx) ?: throw AccountNotFoundException()
-
+        refreshTokenRepository.deleteById(refreshToken)
         return jwtGenerator.generateToken(account.idx, account.authority)
     }
 

--- a/src/test/kotlin/com/project/goms/domain/auth/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/project/goms/domain/auth/ReissueTokenUseCaseTest.kt
@@ -37,10 +37,15 @@ class ReissueTokenUseCaseTest: BehaviorSpec({
         every { jwtParser.parseRefreshToken(refreshToken) } returns parsedRefreshToken
         every { refreshTokenRepository.findByIdOrNull(parsedRefreshToken) } returns refreshTokenEntity
         every { accountRepository.findByIdOrNull(refreshTokenEntity.accountIdx) } returns account
+        every { refreshTokenRepository.deleteById(refreshToken) } returns Unit
         every { jwtGenerator.generateToken(account.idx, account.authority) } returns tokenDto
 
         When("토큰 재발급을 요청하면") {
             val result = reissueTokenUseCase.execute(refreshToken)
+
+            Then("기존의 토큰이 삭제 되어야 한다.") {
+                verify(exactly = 1) {refreshTokenRepository.deleteById(refreshToken) }
+            }
 
             Then("토큰이 재발급 되어야 한다.") {
                 verify(exactly = 1) { jwtGenerator.generateToken(account.idx, account.authority) }


### PR DESCRIPTION
## 💡 개요
+ refreshTokenRepository에 너무 많은 refreshToken이 저장되어있습니다.
## 📃 작업사항
+ 토큰 재발급을 받을 때마다 기존의 refreshToken을 삭제하는 기능을 추가하였습니다.
## 🙋‍♂️ 리뷰내용