### PR TITLE
🔀 :: 외출 안되는 이슈 해결

### DIFF
--- a/src/main/kotlin/com/project/goms/domain/outing/entity/Outing.kt
+++ b/src/main/kotlin/com/project/goms/domain/outing/entity/Outing.kt
@@ -14,6 +14,6 @@ class Outing(
     @JoinColumn(name = "account_idx")
     val account: Account,
 
-    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    @Column(nullable = false, updatable = false)
     val createdTime: LocalTime = LocalTime.now()
 ): BaseIdxEntity(idx)


### PR DESCRIPTION
## 💡 개요
## 📃 작업사항
- outing Entity의 createdTime 필드가 최근에 localTime 타입으로 변환되었는데, createdTime의 columnDefinition을 
DATETIME(6)으로 지정한것을 수정하지 않아서 SQL쪽에서 문제가 발생했습니다.
- columnDefinition을 삭제하고 컬럼 타입을 DATETIME(6) -> TIME으로 수정하였습니다.
## 🙋‍♂️ 리뷰내용