### PR TITLE
🔀 :: 리프레시 토큰 만료시간 수정

### DIFF
--- a/src/main/kotlin/com/project/goms/domain/auth/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/project/goms/domain/auth/entity/RefreshToken.kt
@@ -13,6 +13,6 @@ data class RefreshToken(
 
     val accountIdx: UUID,
 
-    @TimeToLive(unit = TimeUnit.SECONDS)
-    val expiredAt: Int
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    val expiredAt: Long
 )

--- a/src/main/kotlin/com/project/goms/domain/auth/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/project/goms/domain/auth/entity/RefreshToken.kt
@@ -13,6 +13,6 @@ data class RefreshToken(
 
     val accountIdx: UUID,
 
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    @TimeToLive(unit = TimeUnit.SECONDS)
     val expiredAt: Long
 )

--- a/src/main/kotlin/com/project/goms/global/security/jwt/JwtGenerator.kt
+++ b/src/main/kotlin/com/project/goms/global/security/jwt/JwtGenerator.kt
@@ -10,7 +10,6 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
-import java.time.ZoneId
 import java.util.*
 
 @Component
@@ -25,7 +24,7 @@ class JwtGenerator(
             accessToken = generateAccessToken(accountIdx, authority),
             refreshToken = generateRefreshToken(accountIdx),
             accessTokenExp = LocalDateTime.now().plusSeconds(jwtExpTimeProperties.accessExp.toLong()),
-            refreshTokenExp = LocalDateTime.now().plusSeconds(jwtExpTimeProperties.refreshExp.toLong()),
+            refreshTokenExp = LocalDateTime.now().plusSeconds(jwtExpTimeProperties.refreshExp),
             authority = authority
         )
 
@@ -45,7 +44,7 @@ class JwtGenerator(
             .setSubject(accountIdx.toString())
             .claim(JwtProperties.TOKEN_TYPE, JwtProperties.REFRESH)
             .setIssuedAt(Date())
-            .setExpiration(Date.from(LocalDateTime.now().plusMonths(1).atZone(ZoneId.systemDefault()).toInstant()))
+            .setExpiration(Date(System.currentTimeMillis() + jwtExpTimeProperties.refreshExp))
             .compact()
 
         refreshTokenRepository.save(RefreshToken(refreshToken, accountIdx, jwtExpTimeProperties.refreshExp))

--- a/src/main/kotlin/com/project/goms/global/security/jwt/JwtGenerator.kt
+++ b/src/main/kotlin/com/project/goms/global/security/jwt/JwtGenerator.kt
@@ -44,7 +44,7 @@ class JwtGenerator(
             .setSubject(accountIdx.toString())
             .claim(JwtProperties.TOKEN_TYPE, JwtProperties.REFRESH)
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis() + jwtExpTimeProperties.refreshExp))
+            .setExpiration(Date(System.currentTimeMillis() + jwtExpTimeProperties.refreshExp * 1000))
             .compact()
 
         refreshTokenRepository.save(RefreshToken(refreshToken, accountIdx, jwtExpTimeProperties.refreshExp))

--- a/src/main/kotlin/com/project/goms/global/security/jwt/JwtGenerator.kt
+++ b/src/main/kotlin/com/project/goms/global/security/jwt/JwtGenerator.kt
@@ -10,6 +10,7 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.*
 
 @Component
@@ -44,7 +45,7 @@ class JwtGenerator(
             .setSubject(accountIdx.toString())
             .claim(JwtProperties.TOKEN_TYPE, JwtProperties.REFRESH)
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis() + jwtExpTimeProperties.refreshExp * 1000))
+            .setExpiration(Date.from(LocalDateTime.now().plusMonths(1).atZone(ZoneId.systemDefault()).toInstant()))
             .compact()
 
         refreshTokenRepository.save(RefreshToken(refreshToken, accountIdx, jwtExpTimeProperties.refreshExp))

--- a/src/main/kotlin/com/project/goms/global/security/jwt/common/properties/JwtExpTimeProperties.kt
+++ b/src/main/kotlin/com/project/goms/global/security/jwt/common/properties/JwtExpTimeProperties.kt
@@ -7,5 +7,5 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConfigurationProperties("jwt.time")
 class JwtExpTimeProperties(
     val accessExp: Int,
-    val refreshExp: Int
+    val refreshExp: Long
 )


### PR DESCRIPTION
## 💡 개요
- 리프레시 기간에 늘어남에 따라 환경변수의 값도 늘어나 Int로 한다면 리프레시 토큰 만료 기간이 과거로 가는 버그가 발생하였습니다.
## 📃 작업사항
- 만료기간 필드 타입들을 Int에서 Long으로 수정하였습니다.
## 🙋‍♂️ 리뷰내용
- PR을 작성하다가 갑자기 생각이 나서 계속 바꾸다가 계속 커밋을 하게 되었습니다.. 감안하고 봐주시면 감사하겠습니다!
