### PR TITLE
🔀 :: mariaDB 의존성 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 
 	/* DB */
 	implementation("mysql:mysql-connector-java:8.0.32")
+	implementation("org.mariadb.jdbc:mariadb-java-client:2.1.2")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
 	/* spring app */


### PR DESCRIPTION
## 💡 개요
- 개발서버에서 mariaDB를 사용하는데, 의존성이 없어 어플리케이션이 실행되지 않았습니다.
## 📃 작업사항
- maraDB 의존성을 추가하였습니다.
## 🙋‍♂️ 리뷰내용