### PR TITLE
🔀 :: LocalDateTime 패턴 v2랑 같게 변경

### DIFF
--- a/src/main/kotlin/com/project/goms/domain/auth/presentation/data/response/TokenResponse.kt
+++ b/src/main/kotlin/com/project/goms/domain/auth/presentation/data/response/TokenResponse.kt
@@ -7,9 +7,9 @@ import java.time.LocalDateTime
 data class TokenResponse(
     val accessToken: String,
     val refreshToken: String,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val accessTokenExp: LocalDateTime,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val refreshTokenExp: LocalDateTime,
     val authority: Authority
 )


### PR DESCRIPTION
## 💡 개요
- v1 서버와 v2 서버의 LocalDateTime 패턴이 다른걸 발견하였습니다.
## 📃 작업사항
- LocalDateTime 패턴을 `yyyy-MM-dd'T'HH-mm-ss` -> `yyyy-MM-dd'T'HH:mm:ss` 으로 변경하였습니다.
## 🙋‍♂️ 리뷰내용