### PR TITLE
🔀 :: cd 스크립트 이름 대문자에서 소문자로 변경

### DIFF
--- a/.github/workflows/CD-Prod.yml
+++ b/.github/workflows/CD-Prod.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.CLOUDTYPE_TOKEN }}
           ghtoken: ${{ secrets.GHP_TOKEN }}
 
-      - name: Deploy
+      - name: deploy
         uses: cloudtype-github-actions/deploy@v1
         with:
           token: ${{ secrets.CLOUDTYPE_TOKEN }}


### PR DESCRIPTION
## 💡 개요
- cd 스크립트에서 이름이 대문자로 시작하는 것이 있어서 cd가 실패하였다.
## 📃 작업사항
- 대문자로 시작하는 이름을 소문자로 변경
## 🙋‍♂️ 리뷰내용