### PR TITLE
🔀  :: outingBlackList 에서 지각자 수 가져오기

### DIFF
--- a/src/main/kotlin/com/project/goms/domain/late/entity/repository/LateRepository.kt
+++ b/src/main/kotlin/com/project/goms/domain/late/entity/repository/LateRepository.kt
@@ -1,15 +1,11 @@
 package com.project.goms.domain.late.entity.repository
 
 import com.project.goms.domain.late.entity.Late
-import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
-import java.time.LocalDate
 import java.util.UUID
 
 interface LateRepository: CrudRepository<Late, UUID> {
 
     fun countByAccountIdx(accountIdx: UUID): Long
-    @Query("select count(*) from late l where l.createdTime = :oneWeekAgo")
-    fun lateCountOntWeekAgo(oneWeekAgo: LocalDate): Long
 
 }

--- a/src/main/kotlin/com/project/goms/domain/notification/usecase/SendNotificationUseCase.kt
+++ b/src/main/kotlin/com/project/goms/domain/notification/usecase/SendNotificationUseCase.kt
@@ -2,57 +2,50 @@ package com.project.goms.domain.notification.usecase
 
 import com.project.goms.domain.notification.common.exception.DeviceTokenNotFoundException
 import com.project.goms.domain.notification.spi.NotificationPort
-import com.project.goms.domain.late.entity.repository.LateRepository
 import com.project.goms.domain.notification.entity.*
 import com.project.goms.domain.notification.entity.repository.DeviceTokenRepository
+import com.project.goms.domain.outing.entity.repository.OutingBlackListRepository
 import com.project.goms.domain.outing.entity.repository.OutingRepository
 import com.project.goms.global.annotation.UseCaseWithReadOnlyTransaction
 import org.springframework.data.repository.findByIdOrNull
-import java.time.LocalDate
 import java.util.*
 
 @UseCaseWithReadOnlyTransaction
 class SendNotificationUseCase(
-    private val lateRepository: LateRepository,
+    private val outingBlackListRepository: OutingBlackListRepository,
     private val notificationPort: NotificationPort,
     private val deviceTokenRepository: DeviceTokenRepository,
     private val outingRepository: OutingRepository,
 ) {
 
     fun execute(notificationType: NotificationType) {
-        val oneWeekAgo = LocalDate.now().minusWeeks(1)
 
         when (notificationType) {
             // 외출 전 지난주 지각자 수에 따라서 외출 알림 발송
             NotificationType.BEFORE_OUTING -> {
-                runCatching {
-                    when (lateRepository.lateCountOntWeekAgo(oneWeekAgo) < 3) {
-                        true -> {
-                            notificationPort.sendNotification(
-                                deviceTokens = deviceTokenRepository.findAll().map { it.token },
-                                notification = Notification(
-                                    title = Topic.BEFORE_OUTING.title,
-                                    content = Topic.BEFORE_OUTING.content,
-                                    writer = Writer.GOMS
-                                )
+                when (outingBlackListRepository.count() < 3) {
+                    true -> {
+                        notificationPort.sendNotification(
+                            deviceTokens = deviceTokenRepository.findAll().map { it.token },
+                            notification = Notification(
+                                title = Topic.BEFORE_OUTING.title,
+                                content = Topic.BEFORE_OUTING.content,
+                                writer = Writer.GOMS
                             )
-                        }
-
-                        false -> {
-                            notificationPort.sendNotification(
-                                deviceTokens = deviceTokenRepository.findAll().map { it.token },
-                                notification = Notification(
-                                    title = Topic.GROUNDED.title,
-                                    content = Topic.GROUNDED.content,
-                                    writer = Writer.GOMS
-                                )
-                            )
-                        }
+                        )
                     }
-                }.onFailure {
-                    it.printStackTrace()
-                }
 
+                    false -> {
+                        notificationPort.sendNotification(
+                            deviceTokens = deviceTokenRepository.findAll().map { it.token },
+                            notification = Notification(
+                                title = Topic.GROUNDED.title,
+                                content = Topic.GROUNDED.content,
+                                writer = Writer.GOMS
+                            )
+                        )
+                    }
+                }
             }
 
             // 외출 5분 전 아직 복귀하지 않은 학생들에게 알림 발송


### PR DESCRIPTION
## 💡 개요
+ FCM 알림을 보내는 부분에서 지각자 수를 파악하는 로직을 리펙토링 하였습니다.
## 📃 작업사항
+ `lateRepository`에서 쿼리메서드로 지각자 수를 가져오는 기존의 방법에서 `outingBlackList`에서 `count()` 메서드로 가져올 수 있도록 리펙토링 하였습니다.
